### PR TITLE
Fix typo in midterm-1-study-guide.md TCB section.

### DIFF
--- a/information-security/midterm-1-study-guide.md
+++ b/information-security/midterm-1-study-guide.md
@@ -507,7 +507,7 @@ The Trusted Computing Base or TCB has 3 main requirements which of the following
 - A.) Complete mediation between the OS and the hardware resources and applications. In addition the OS must make sure the application has the necessary authorizations.
 - B.) The OS must be tamperproof.
 - C.) The OS must must be able to go from user to kernel mode without errors
-- D.)The OS must be correct­­ the protected resources are used properly
+- D.) The OS must be correct and ensures that protected resources are used properly
 
 <details>
 <summary>Answer</summary> C


### PR DESCRIPTION
Fixed awkward wording:

"The OS must be correct­­ the protected resources are used properly" is now "The OS must be correct and ensures that protected resources are used properly"