### PR TITLE
[TYPO] Operating Systems - Scheduling

### DIFF
--- a/operating-systems/scheduling.md
+++ b/operating-systems/scheduling.md
@@ -114,7 +114,7 @@ A further modification that makes sense with round robin is not to wait until th
 ![](https://assets.omscs.io/notes/AED712E3-7C9D-4E10-B5CD-48ACB79788FA.png)
 
 ## Timesharing and Timeslices
-A **timeslice** (also known as a time quantum) is the maximum amount of uninterrupted time that can be given to a task. A task may run for a smaller amount of time than what the timeslice specifies. If the task needs to be wait on an I/O operation, or synchronize with another task, the task will execute for less than its timeslice before it is placed on the appropriate queue and preempted. Also, if a higher priority tasks becomes runnable for a lower priority task's timeslice has expired, the lower priority task will be preempted.
+A **timeslice** (also known as a time quantum) is the maximum amount of uninterrupted time that can be given to a task. A task may run for a smaller amount of time than what the timeslice specifies. If the task needs to be wait on an I/O operation, or synchronize with another task, the task will execute for less than its timeslice before it is placed on the appropriate queue and preempted. Also, if a higher priority tasks becomes runnable before a lower priority task's timeslice has expired, the lower priority task will be preempted.
 
 The use of timeslices allows for the tasks to be interleaved. That is, they will be timesharing the CPU. For I/O bound tasks, this is not super critical, as these tasks will often be placed on wait queues. However, for CPU bound tasks, timeslices are the only way that we can achieve timesharing.
 


### PR DESCRIPTION
What needs to be fixed?
Please be specific as possible and add a link to the relevant file/lines.

Relevant section: https://www.omscs-notes.com/operating-systems/scheduling/#scheduling-overview

Second paragraph: Changed `if a higher priority tasks becomes runnable for a lower priority task's timeslice has expired` to `if a higher priority tasks becomes runnable before a lower priority task's timeslice has expired`